### PR TITLE
fix a ci error

### DIFF
--- a/dspace-api/src/test/java/org/dspace/authorize/AuthorizeConfigIT.java
+++ b/dspace-api/src/test/java/org/dspace/authorize/AuthorizeConfigIT.java
@@ -16,9 +16,8 @@ import org.junit.Test;
 /**
  * This integration test verify that the {@link AuthorizeConfiguration} works
  * properly with the configuration reloading
- * 
- * @author Andrea Bollini (andrea.bollini at 4science.it)
  *
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
 public class AuthorizeConfigIT extends AbstractIntegrationTest {
 
@@ -33,7 +32,7 @@ public class AuthorizeConfigIT extends AbstractIntegrationTest {
         // in our extra configuration file for test, disable some feature
         appendToLocalConfiguration(
             "core.authorization.community-admin.group = false\n" +
-            "core.authorization.community-admin.delete-subelement = false\n");
+                "core.authorization.community-admin.delete-subelement = false\n");
         // verify that the two changed one are reflected in the AuthorizationConfiguration
         assertFalse(AuthorizeConfiguration.canCommunityAdminPerformGroupCreation());
         assertFalse(AuthorizeConfiguration.canCommunityAdminPerformSubelementDeletion());
@@ -43,7 +42,7 @@ public class AuthorizeConfigIT extends AbstractIntegrationTest {
 
         // add other configuration to switch off also the third
         appendToLocalConfiguration(
-                "core.authorization.community-admin.create-subelement = false\n");
+            "core.authorization.community-admin.create-subelement = false\n");
 
         assertFalse(AuthorizeConfiguration.canCommunityAdminPerformSubelementCreation());
         assertFalse(AuthorizeConfiguration.canCommunityAdminPerformGroupCreation());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
@@ -82,7 +82,7 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
             relationshipTypeService.delete(context, relationshipType);
         }
 
-        for (EntityType entityType: entityTypeList) {
+        for (EntityType entityType : entityTypeList) {
             entityTypeService.delete(context, entityType);
         }
         context.restoreAuthSystemState();
@@ -92,7 +92,6 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
 
     /**
      * Verifies that the initialize-entities script ran properly and that the objects are created properly
-     * @throws Exception
      */
     @Test
     public void getAllRelationshipTypesTest() throws Exception {
@@ -101,30 +100,30 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
         getClient().perform(get("/api/core/relationshiptypes")
                 .param("projection", "full"))
 
-                //We expect a 200 OK status
-                .andExpect(status().isOk())
-                //10 relationship types should be created
-                .andExpect(jsonPath("$.page.totalElements", is(10)))
-                //There needs to be a self link to this endpoint
-                .andExpect(jsonPath("$._links.self.href", containsString("api/core/relationshiptypes")))
-                //We have 10 relationship types, they need to all be present in the embedded section
-                .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(0)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(1)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(2)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(3)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(4)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(5)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(6)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(7)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(8)),
-                        RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(9)))
-                ));
+            //We expect a 200 OK status
+            .andExpect(status().isOk())
+            //10 relationship types should be created
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            //There needs to be a self link to this endpoint
+            .andExpect(jsonPath("$._links.self.href", containsString("api/core/relationshiptypes")))
+            //We have 10 relationship types, they need to all be present in the embedded section
+            .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(0)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(1)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(2)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(3)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(4)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(5)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(6)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(7)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(8)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(9)))
+            ));
 
         //Verify the left min cardinality of the first relationship type (isAuthorOfPublication) is 0
         getClient().perform(get("/api/core/relationshiptypes/" + relationshipTypes.get(0).getID()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.leftMinCardinality", is(0)));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.leftMinCardinality", is(0)));
     }
 
     /**
@@ -145,36 +144,36 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
         // File and thus by running the script, the RelationshipType object in the Database should be the same as our
         // alteredRelationshipType object that we just created.
         // It's important to note that this object will not alter anything in the Database, this object is merely
-        // made for the comparison between the REST response and we expect to have happened through the script
+        // made for the comparison between the REST response, and we expect to have happened through the script
         RelationshipType alteredRelationshipType = relationshipTypes.get(0);
         alteredRelationshipType.setLeftMinCardinality(10);
         getClient().perform(get("/api/core/relationshiptypes")
-                   .param("projection", "full"))
+                .param("projection", "full"))
 
-                   //We expect a 200 OK status
-                   .andExpect(status().isOk())
-                   //10 relationship types should remain present (no duplicates created)
-                   .andExpect(jsonPath("$.page.totalElements", is(10)))
-                   //There needs to be a self link to this endpoint
-                   .andExpect(jsonPath("$._links.self.href", containsString("api/core/relationshiptypes")))
-                   //We have 10 relationship types, they need to all be present in the embedded section
-                   //Verify the left min cardinality of the isAuthorOfPublication has been updated to 10
-                   .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(alteredRelationshipType),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(1)),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(2)),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(3)),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(4)),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(5)),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(6)),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(7)),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(8)),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(9)))
-                   ));
+            //We expect a 200 OK status
+            .andExpect(status().isOk())
+            //10 relationship types should remain present (no duplicates created)
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            //There needs to be a self link to this endpoint
+            .andExpect(jsonPath("$._links.self.href", containsString("api/core/relationshiptypes")))
+            //We have 10 relationship types, they need to all be present in the embedded section
+            //Verify the left min cardinality of the isAuthorOfPublication has been updated to 10
+            .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(alteredRelationshipType),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(1)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(2)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(3)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(4)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(5)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(6)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(7)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(8)),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipTypes.get(9)))
+            ));
 
         //Verify the left min cardinality of the first relationship type (isAuthorOfPublication) has been updated to 10
         getClient().perform(get("/api/core/relationshiptypes/" + relationshipTypes.get(0).getID()))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.leftMinCardinality", is(10)));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.leftMinCardinality", is(10)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
@@ -6,6 +6,7 @@
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest;
+
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -47,20 +48,19 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
 
         getClient().perform(get("/api/core/entitytypes"))
 
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7))))
-                   .andExpect(jsonPath("$._embedded.entitytypes", containsInAnyOrder(
-                       EntityTypeMatcher.matchEntityTypeEntryForLabel("Publication"),
-                       EntityTypeMatcher.matchEntityTypeEntryForLabel("Person"),
-                       EntityTypeMatcher.matchEntityTypeEntryForLabel("Project"),
-                       EntityTypeMatcher.matchEntityTypeEntryForLabel("OrgUnit"),
-                       EntityTypeMatcher.matchEntityTypeEntryForLabel("Journal"),
-                       EntityTypeMatcher.matchEntityTypeEntryForLabel("JournalVolume"),
-                       EntityTypeMatcher.matchEntityTypeEntryForLabel("JournalIssue")
-
-                   )))
-        ;
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page",
+                is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 8))))
+            .andExpect(jsonPath("$._embedded.entitytypes", containsInAnyOrder(
+                EntityTypeMatcher.matchEntityTypeEntryForLabel("Publication"),
+                EntityTypeMatcher.matchEntityTypeEntryForLabel("Person"),
+                EntityTypeMatcher.matchEntityTypeEntryForLabel("Project"),
+                EntityTypeMatcher.matchEntityTypeEntryForLabel("OrgUnit"),
+                EntityTypeMatcher.matchEntityTypeEntryForLabel("Journal"),
+                EntityTypeMatcher.matchEntityTypeEntryForLabel("JournalVolume"),
+                EntityTypeMatcher.matchEntityTypeEntryForLabel("JournalIssue"),
+                EntityTypeMatcher.matchEntityTypeEntryForLabel("none")
+            )));
     }
 
     @Test
@@ -74,31 +74,31 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
 
         RelationshipType relationshipType1 = relationshipTypeService
             .findbyTypesAndTypeName(context, publicationEntityType, personEntityType, "isAuthorOfPublication",
-                                  "isPublicationOfAuthor");
+                "isPublicationOfAuthor");
         RelationshipType relationshipType2 = relationshipTypeService
             .findbyTypesAndTypeName(context, publicationEntityType, projectEntityType, "isProjectOfPublication",
-                                  "isPublicationOfProject");
+                "isPublicationOfProject");
         RelationshipType relationshipType3 = relationshipTypeService
             .findbyTypesAndTypeName(context, publicationEntityType, orgunitEntityType, "isOrgUnitOfPublication",
-                                  "isPublicationOfOrgUnit");
+                "isPublicationOfOrgUnit");
         RelationshipType relationshipType4 = relationshipTypeService
             .findbyTypesAndTypeName(context, journalIssueEntityType, publicationEntityType,
-                    "isPublicationOfJournalIssue", "isJournalIssueOfPublication");
+                "isPublicationOfJournalIssue", "isJournalIssueOfPublication");
         RelationshipType relationshipType5 = relationshipTypeService
             .findbyTypesAndTypeName(context, publicationEntityType, orgunitEntityType, "isAuthorOfPublication",
-                                  "isPublicationOfAuthor");
+                "isPublicationOfAuthor");
         getClient().perform(get("/api/core/entitytypes/" + publicationEntityType.getID() + "/relationshiptypes"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType1),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType2),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType3),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType4),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType5)
-                       )))
-                   .andExpect(jsonPath("$.page.size", is(20)))
-                   .andExpect(jsonPath("$.page.totalElements", is(5)))
-                   .andExpect(jsonPath("$.page.number", is(0)));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType1),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType2),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType3),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType4),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType5)
+            )))
+            .andExpect(jsonPath("$.page.size", is(20)))
+            .andExpect(jsonPath("$.page.totalElements", is(5)))
+            .andExpect(jsonPath("$.page.number", is(0)));
     }
 
     @Test
@@ -108,11 +108,11 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/entitytypes/" + testEntityType.getID() + "/relationshiptypes"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.relationshiptypes").isEmpty())
-                   .andExpect(jsonPath("$.page.size", is(20)))
-                   .andExpect(jsonPath("$.page.totalElements", is(0)))
-                   .andExpect(jsonPath("$.page.number", is(0)));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.relationshiptypes").isEmpty())
+            .andExpect(jsonPath("$.page.size", is(20)))
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$.page.number", is(0)));
     }
 
     @Test
@@ -125,49 +125,49 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
         EntityType journalIssue = entityTypeService.findByEntityType(context, "journalIssue");
 
         RelationshipType relationshipType1 = relationshipTypeService.findbyTypesAndTypeName(context,
-                             publication, person, "isAuthorOfPublication", "isPublicationOfAuthor");
+            publication, person, "isAuthorOfPublication", "isPublicationOfAuthor");
         RelationshipType relationshipType2 = relationshipTypeService.findbyTypesAndTypeName(context,
-                          publication, project, "isProjectOfPublication", "isPublicationOfProject");
+            publication, project, "isProjectOfPublication", "isPublicationOfProject");
         RelationshipType relationshipType3 = relationshipTypeService.findbyTypesAndTypeName(context,
-                          publication, orgunit, "isOrgUnitOfPublication", "isPublicationOfOrgUnit");
+            publication, orgunit, "isOrgUnitOfPublication", "isPublicationOfOrgUnit");
         RelationshipType relationshipType4 = relationshipTypeService.findbyTypesAndTypeName(context,
-           journalIssue, publication, "isPublicationOfJournalIssue", "isJournalIssueOfPublication");
+            journalIssue, publication, "isPublicationOfJournalIssue", "isJournalIssueOfPublication");
         RelationshipType relationshipType5 = relationshipTypeService.findbyTypesAndTypeName(context,
-                             publication, orgunit, "isAuthorOfPublication","isPublicationOfAuthor");
+            publication, orgunit, "isAuthorOfPublication", "isPublicationOfAuthor");
 
         getClient().perform(get("/api/core/entitytypes/" + publication.getID() + "/relationshiptypes")
-                   .param("size", "2"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType1),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType2)
-                       )))
-                   .andExpect(jsonPath("$.page.size", is(2)))
-                   .andExpect(jsonPath("$.page.totalElements", is(5)))
-                   .andExpect(jsonPath("$.page.number", is(0)));
+                .param("size", "2"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType1),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType2)
+            )))
+            .andExpect(jsonPath("$.page.size", is(2)))
+            .andExpect(jsonPath("$.page.totalElements", is(5)))
+            .andExpect(jsonPath("$.page.number", is(0)));
 
         getClient().perform(get("/api/core/entitytypes/" + publication.getID() + "/relationshiptypes")
-                   .param("size", "2")
-                   .param("page", "1"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType3),
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType5)
-                       )))
-                   .andExpect(jsonPath("$.page.size", is(2)))
-                   .andExpect(jsonPath("$.page.totalElements", is(5)))
-                   .andExpect(jsonPath("$.page.number", is(1)));
+                .param("size", "2")
+                .param("page", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.relationshiptypes", containsInAnyOrder(
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType3),
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType5)
+            )))
+            .andExpect(jsonPath("$.page.size", is(2)))
+            .andExpect(jsonPath("$.page.totalElements", is(5)))
+            .andExpect(jsonPath("$.page.number", is(1)));
 
         getClient().perform(get("/api/core/entitytypes/" + publication.getID() + "/relationshiptypes")
-                   .param("size", "2")
-                   .param("page", "2"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.relationshiptypes", contains(
-                       RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType4)
-                       )))
-                   .andExpect(jsonPath("$.page.size", is(2)))
-                   .andExpect(jsonPath("$.page.totalElements", is(5)))
-                   .andExpect(jsonPath("$.page.number", is(2)));
+                .param("size", "2")
+                .param("page", "2"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.relationshiptypes", contains(
+                RelationshipTypeMatcher.matchRelationshipTypeEntry(relationshipType4)
+            )))
+            .andExpect(jsonPath("$.page.size", is(2)))
+            .andExpect(jsonPath("$.page.totalElements", is(5)))
+            .andExpect(jsonPath("$.page.number", is(2)));
     }
 
     @Test
@@ -181,29 +181,29 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
 
         RelationshipType relationshipType1 = relationshipTypeService
             .findbyTypesAndTypeName(context, publicationEntityType, personEntityType, "isAuthorOfPublication",
-                                  "isPublicationOfAuthor");
+                "isPublicationOfAuthor");
         RelationshipType relationshipType2 = relationshipTypeService
             .findbyTypesAndTypeName(context, publicationEntityType, projectEntityType, "isProjectOfPublication",
-                                  "isPublicationOfProject");
+                "isPublicationOfProject");
         RelationshipType relationshipType3 = relationshipTypeService
             .findbyTypesAndTypeName(context, publicationEntityType, orgunitEntityType, "isOrgUnitOfPublication",
-                                  "isPublicationOfOrgUnit");
+                "isPublicationOfOrgUnit");
         RelationshipType relationshipType4 = relationshipTypeService
             .findbyTypesAndTypeName(context, journalIssueEntityType, publicationEntityType,
-                    "isPublicationOfJournalIssue", "isJournalIssueOfPublication");
+                "isPublicationOfJournalIssue", "isJournalIssueOfPublication");
         RelationshipType relationshipType5 = relationshipTypeService
             .findbyTypesAndTypeName(context, publicationEntityType, orgunitEntityType, "isAuthorOfPublication",
-                                  "isPublicationOfAuthor");
+                "isPublicationOfAuthor");
 
         String adminToken = getAuthToken(admin.getEmail(), password);
         getClient(adminToken).perform(get("/api/core/relationships?embed=relationshipType"))
-                             .andExpect(status().isOk());
+            .andExpect(status().isOk());
     }
 
     @Test
     public void findAllRelationshipTypesNotFoundTest() throws Exception {
         getClient().perform(get("/api/core/entitytypes/" + Integer.MAX_VALUE + "/relationshiptypes"))
-                   .andExpect(status().isNotFound());
+            .andExpect(status().isNotFound());
     }
 
     @Test
@@ -213,75 +213,75 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
 
 
         parentCommunity = CommunityBuilder.createCommunity(context)
-                                          .withName("Parent Community")
-                                          .build();
+            .withName("Parent Community")
+            .build();
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-                                           .withName("Sub Community")
-                                           .build();
+            .withName("Sub Community")
+            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1")
-                                           .withEntityType("Person").build();
+            .withEntityType("Person").build();
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2")
-                                           .withEntityType("Person").build();
+            .withEntityType("Person").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits")
-                                           .withEntityType("OrgUnit").build();
+            .withEntityType("OrgUnit").build();
         Collection col4 = CollectionBuilder.createCollection(context, child1).withName("Publications")
-                                           .withEntityType("Publication").build();
+            .withEntityType("Publication").build();
         Collection col5 = CollectionBuilder.createCollection(context, child1).withName("without entityType")
-                                           .build();
+            .build();
 
         Item author1 = ItemBuilder.createItem(context, col1)
-                                  .withTitle("Author1")
-                                  .withIssueDate("2017-10-17")
-                                  .withAuthor("Smith, Donald")
-                                  .build();
+            .withTitle("Author1")
+            .withIssueDate("2017-10-17")
+            .withAuthor("Smith, Donald")
+            .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author2")
-                                  .withIssueDate("2016-02-13")
-                                  .withAuthor("Smith, Maria")
-                                  .build();
+            .withTitle("Author2")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Smith, Maria")
+            .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
-                                  .withTitle("Author3")
-                                  .withIssueDate("2016-02-13")
-                                  .withAuthor("Maybe, Maybe")
-                                  .build();
+            .withTitle("Author3")
+            .withIssueDate("2016-02-13")
+            .withAuthor("Maybe, Maybe")
+            .build();
 
         Item orgUnit1 = ItemBuilder.createItem(context, col3)
-                                   .withTitle("OrgUnit1")
-                                   .withAuthor("Testy, TEst")
-                                   .withIssueDate("2015-01-01")
-                                   .build();
+            .withTitle("OrgUnit1")
+            .withAuthor("Testy, TEst")
+            .withIssueDate("2015-01-01")
+            .build();
 
         Item project1 = ItemBuilder.createItem(context, col5)
-                                   .withTitle("Project1")
-                                   .withAuthor("Testy, TEst")
-                                   .withIssueDate("2015-01-01")
-                                   .build();
+            .withTitle("Project1")
+            .withAuthor("Testy, TEst")
+            .withIssueDate("2015-01-01")
+            .build();
 
         Item publication = ItemBuilder.createItem(context, col4)
-                                      .withTitle("Publication1")
-                                      .withAuthor("Testy, TEst")
-                                      .withIssueDate("2015-01-01")
-                                      .build();
+            .withTitle("Publication1")
+            .withAuthor("Testy, TEst")
+            .withIssueDate("2015-01-01")
+            .build();
 
         Item publication2 = ItemBuilder.createItem(context, col4)
-                                       .withTitle("Publication2")
-                                       .withIssueDate("2015-01-01")
-                                       .build();
+            .withTitle("Publication2")
+            .withIssueDate("2015-01-01")
+            .build();
 
         RelationshipType isOrgUnitOfPersonRelationshipType = relationshipTypeService
             .findbyTypesAndTypeName(context, entityTypeService.findByEntityType(context, "Person"),
-                                  entityTypeService.findByEntityType(context, "OrgUnit"),
-                                  "isOrgUnitOfPerson", "isPersonOfOrgUnit");
+                entityTypeService.findByEntityType(context, "OrgUnit"),
+                "isOrgUnitOfPerson", "isPersonOfOrgUnit");
         RelationshipType isOrgUnitOfProjectRelationshipType = relationshipTypeService
             .findbyTypesAndTypeName(context, entityTypeService.findByEntityType(context, "Project"),
-                                  entityTypeService.findByEntityType(context, "OrgUnit"),
-                                  "isOrgUnitOfProject", "isProjectOfOrgUnit");
+                entityTypeService.findByEntityType(context, "OrgUnit"),
+                "isOrgUnitOfProject", "isProjectOfOrgUnit");
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
             .findbyTypesAndTypeName(context, entityTypeService.findByEntityType(context, "Publication"),
-                                  entityTypeService.findByEntityType(context, "Person"),
-                                  "isAuthorOfPublication", "isPublicationOfAuthor");
+                entityTypeService.findByEntityType(context, "Person"),
+                "isAuthorOfPublication", "isPublicationOfAuthor");
 
         Relationship relationship1 = RelationshipBuilder
             .createRelationshipBuilder(context, publication, author1, isAuthorOfPublicationRelationshipType).build();
@@ -295,51 +295,51 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
         context.restoreAuthSystemState();
         //verify results
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication")
-                   .param("projection", "full"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
-                       RelationshipMatcher.matchRelationship(relationship1),
-                       RelationshipMatcher.matchRelationship(relationship2),
-                       RelationshipMatcher.matchRelationship(relationship3),
-                       RelationshipMatcher.matchRelationship(relationship4)
-                   )));
+                .param("projection", "full"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                RelationshipMatcher.matchRelationship(relationship1),
+                RelationshipMatcher.matchRelationship(relationship2),
+                RelationshipMatcher.matchRelationship(relationship3),
+                RelationshipMatcher.matchRelationship(relationship4)
+            )));
 
         //verify paging
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&size=2"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page.totalElements", is(4)));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(4)));
 
         //verify results
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
-                                    + publication.getID())
-                   .param("projection", "full"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
-                       RelationshipMatcher.matchRelationship(relationship1),
-                       RelationshipMatcher.matchRelationship(relationship2)
-                   )));
+                + publication.getID())
+                .param("projection", "full"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                RelationshipMatcher.matchRelationship(relationship1),
+                RelationshipMatcher.matchRelationship(relationship2)
+            )));
 
         //verify paging
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
-                                    + publication.getID() + "&size=1"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page.totalElements", is(2)));
+                + publication.getID() + "&size=1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
 
         //verify results
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
-                                    + publication2.getID())
-                   .param("projection", "full"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
-                       RelationshipMatcher.matchRelationship(relationship3),
-                       RelationshipMatcher.matchRelationship(relationship4)
-                   )));
+                + publication2.getID())
+                .param("projection", "full"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                RelationshipMatcher.matchRelationship(relationship3),
+                RelationshipMatcher.matchRelationship(relationship4)
+            )));
 
         //verify paging
         getClient().perform(get("/api/core/relationships/search/byLabel?label=isAuthorOfPublication&dso="
-                                    + publication2.getID() + "&size=1"))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.page.totalElements", is(2)));
+                + publication2.getID() + "&size=1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
 
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractEntityIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractEntityIntegrationTest.java
@@ -18,13 +18,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class AbstractEntityIntegrationTest extends AbstractControllerIntegrationTest {
 
     @Autowired
-    private EntityTypeService entityTypeService;
-    @Autowired
     protected RelationshipTypeService relationshipTypeService;
+    @Autowired
+    private EntityTypeService entityTypeService;
 
     /**
      * This method will call the setUp method from AbstractControllerIntegrationTest.
-     * Afterwards it will setUp the entity relation structure as defined in
+     * Afterwards it will set up the entity relation structure as defined in
      * dspace-api/src/test/data/dspaceFolder/config/entities/relationship-types.xml
      *
      * This method will first build the following EntityTypes:
@@ -61,56 +61,56 @@ public class AbstractEntityIntegrationTest extends AbstractControllerIntegration
 
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, publication, person, "isAuthorOfPublication",
-                                                              "isPublicationOfAuthor", 0, null, 0,
-                                                              null).withCopyToLeft(false).withCopyToRight(true).build();
+            "isPublicationOfAuthor", 0, null, 0,
+            null).withCopyToLeft(false).withCopyToRight(true).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, publication, project, "isProjectOfPublication",
-                                                              "isPublicationOfProject", 0, null, 0,
-                                                              null).withCopyToRight(true).build();
+            "isPublicationOfProject", 0, null, 0,
+            null).withCopyToRight(true).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, publication, orgUnit, "isOrgUnitOfPublication",
-                                                              "isPublicationOfOrgUnit", 0, null, 0,
-                                                              null).withCopyToLeft(false).build();
+            "isPublicationOfOrgUnit", 0, null, 0,
+            null).withCopyToLeft(false).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, person, project, "isProjectOfPerson",
-                                                              "isPersonOfProject", 0, null, 0,
-                                                              null).withCopyToLeft(true).withCopyToRight(true).build();
+            "isPersonOfProject", 0, null, 0,
+            null).withCopyToLeft(true).withCopyToRight(true).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, person, orgUnit, "isOrgUnitOfPerson",
-                                                              "isPersonOfOrgUnit", 0, null, 0,
-                                                              null).build();
+            "isPersonOfOrgUnit", 0, null, 0,
+            null).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, project, orgUnit, "isOrgUnitOfProject",
-                                                              "isProjectOfOrgUnit", 0, null, 0,
-                                                              null).build();
+            "isProjectOfOrgUnit", 0, null, 0,
+            null).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, journal, journalVolume, "isVolumeOfJournal",
-                                                              "isJournalOfVolume", 0, null, 1,
-                                                              null).withCopyToLeft(true).build();
+            "isJournalOfVolume", 0, null, 1,
+            null).withCopyToLeft(true).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, journalVolume, journalIssue,
-                                                              "isIssueOfJournalVolume", "isJournalVolumeOfIssue", 0,
-                                                              null, 1,
-                                                              1).build();
+            "isIssueOfJournalVolume", "isJournalVolumeOfIssue", 0,
+            null, 1,
+            1).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, journalIssue, journalVolume,
-                                                                "isJournalVolumeOfIssue", "isIssueOfJournalVolume",
-                                                                null, null, null,
-                                                                null).build();
+            "isJournalVolumeOfIssue", "isIssueOfJournalVolume",
+            null, null, null,
+            null).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, publication, orgUnit, "isAuthorOfPublication",
-                                                              "isPublicationOfAuthor", 0, null, 0,
-                                                              null).build();
+            "isPublicationOfAuthor", 0, null, 0,
+            null).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, journalIssue, publication,
-                                                              "isPublicationOfJournalIssue",
-                                                              "isJournalIssueOfPublication", 0, null, 0,
-                                                              1).build();
+            "isPublicationOfJournalIssue",
+            "isJournalIssueOfPublication", 0, null, 0,
+            1).build();
 
         RelationshipTypeBuilder.createRelationshipTypeBuilder(context, orgUnit, orgUnit, "isParentOrgUnitOf",
-                                                              "isChildOrgUnitOf", null,
-                                                              1, null, null)
-                               .build();
+                "isChildOrgUnitOf", null,
+                1, null, null)
+            .build();
 
         context.restoreAuthSystemState();
     }


### PR DESCRIPTION
Suddenly the CI fails due to the test failure of the `RelationshipTypeRestControllerIT.findAllEntityTypes()`

Fixed by considering a default entity type "none" is always created.