### PR TITLE
Speed up OAI harvesting

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
@@ -378,7 +378,9 @@ public class Harvest extends DSpaceRunnable<HarvestScriptConfiguration> {
         try {
             // Harvest will not work for an anonymous user
             handler.logInfo("Harvest started... ");
-            harvester.runHarvest();
+            int recentDays =
+                commandLine.hasOption("recent") ? Integer.parseInt(commandLine.getOptionValue("recent")) : -1;
+            harvester.runHarvest(recentDays);
             context.complete();
         } catch (SQLException | AuthorizeException | IOException e) {
             throw new IllegalStateException("Failed to run harvester", e);

--- a/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
@@ -399,6 +399,7 @@ public class Harvest extends DSpaceRunnable<HarvestScriptConfiguration> {
             for (HarvestedCollection harvestedCollection : harvestedCollections) {
                 //hc.setHarvestResult(null,"");
                 harvestedCollection.setHarvestStartTime(null);
+                harvestedCollection.setLastHarvested(null);
                 harvestedCollection.setHarvestStatus(HarvestedCollection.STATUS_READY);
                 harvestedCollectionService.update(context, harvestedCollection);
             }

--- a/dspace-api/src/main/java/org/dspace/app/harvest/HarvestScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/HarvestScriptConfiguration.java
@@ -65,6 +65,8 @@ public class HarvestScriptConfiguration<T extends Harvest> extends ScriptConfigu
             "type of harvesting (0 for none)");
         options.addOption("a", "address", true,
             "address of the OAI-PMH server");
+        options.addOption("recent", "recent_days", true,
+            "only harvest the records within the specified number of days in the recent past");
         options.addOption("i", "oai_set_id", true,
             "id of the PMH set representing the harvested collection");
         options.addOption("m", "metadata_format", true,

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestThread.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestThread.java
@@ -32,7 +32,7 @@ public class HarvestThread extends Thread {
         HarvestServiceFactory.getInstance().getHarvestedCollectionService();
 
 
-    protected HarvestThread(UUID collectionId) throws SQLException {
+    protected HarvestThread(UUID collectionId) {
         this.collectionId = collectionId;
     }
 
@@ -54,14 +54,14 @@ public class HarvestThread extends Thread {
 
                 dso = hc.getCollection();
                 OAIHarvester harvester = new OAIHarvester(context, dso, hc);
-                harvester.runHarvest();
+                harvester.runHarvest(-1);
             } catch (RuntimeException e) {
-                log.error("Runtime exception in thread: " + this.toString());
+                log.error("Runtime exception in thread: " + this);
                 log.error(e.getMessage() + " " + e.getCause());
                 hc.setHarvestMessage("Runtime error occured while generating an OAI response");
                 hc.setHarvestStatus(HarvestedCollection.STATUS_UNKNOWN_ERROR);
             } catch (Exception ex) {
-                log.error("General exception in thread: " + this.toString());
+                log.error("General exception in thread: " + this);
                 log.error(ex.getMessage() + " " + ex.getCause());
                 hc.setHarvestMessage("Error occured while generating an OAI response");
                 hc.setHarvestStatus(HarvestedCollection.STATUS_UNKNOWN_ERROR);
@@ -70,9 +70,6 @@ public class HarvestThread extends Thread {
                     harvestedCollectionService.update(context, hc);
                     context.restoreAuthSystemState();
                     context.complete();
-                } catch (RuntimeException e) {
-                    log.error("Unexpected exception while recovering from a harvesting error: " + e.getMessage(), e);
-                    context.abort();
                 } catch (Exception e) {
                     log.error("Unexpected exception while recovering from a harvesting error: " + e.getMessage(), e);
                     context.abort();
@@ -86,6 +83,7 @@ public class HarvestThread extends Thread {
             log.error(e.getMessage(), e);
         }
 
+        assert hc != null;
         log.info("Thread for collection " + hc.getCollection().getID() + " completes.");
     }
 }

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -333,11 +333,7 @@ public class OAIHarvester {
             oaiSetId = null;
         }
 
-        Date lastHarvestDate = harvestRow.getHarvestDate();
-        String fromDate = null;
-        if (lastHarvestDate != null) {
-            fromDate = processDate(harvestRow.getHarvestDate());
-        }
+        String fromDate = harvestRow.getHarvestDate() == null ? null : processDate(harvestRow.getHarvestDate());
 
         long totalListSize = 0;
         long currentRecord = 0;
@@ -353,9 +349,7 @@ public class OAIHarvester {
             String OREPrefix;
             try {
                 dateGranularity = oaiGetDateGranularity(oaiSource);
-                if (fromDate != null) {
-                    fromDate = fromDate.substring(0, dateGranularity.length());
-                }
+                fromDate = fromDate != null ? fromDate.substring(0, dateGranularity.length()) : null;
                 toDate = toDate.substring(0, dateGranularity.length());
 
                 descMDPrefix = oaiResolveNamespaceToPrefix(oaiSource, metadataNS.getURI());
@@ -520,12 +514,13 @@ public class OAIHarvester {
         // If we got to this point, it means the harvest was completely successful
         Date finishTime = new Date();
         long timeTaken = finishTime.getTime() - startTime.getTime();
-        harvestRow.setHarvestStartTime(startTime);
+        harvestRow.setLastHarvested(finishTime);
         harvestRow.setHarvestMessage("Harvest from " + oaiSource + " successful");
         harvestRow.setHarvestStatus(HarvestedCollection.STATUS_READY);
         log.info(
             "Harvest from " + oaiSource + " successful. The process took " + timeTaken + " milliseconds. Harvested "
-                + currentRecord + " items.");
+                + currentRecord + " items. Harvesting speed is " + (currentRecord / (timeTaken / 1000)) +
+                " items/second.");
         harvestedCollectionService.update(ourContext, harvestRow);
 
         ourContext.setMode(originalMode);

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -315,12 +315,14 @@ public class OAIHarvester {
      * since last
      * harvest, and ingest the returned items.
      *
+     * @param recentDays the number of days to look back for updates, -1 for all updates
+     *
      * @throws IOException        A general class of exceptions produced by failed or interrupted I/O operations.
      * @throws SQLException       An exception that provides information on a database access error or other errors.
      * @throws AuthorizeException Exception indicating the current user of the context does not have permission
      *                            to perform a particular action.
      */
-    public void runHarvest() throws SQLException, IOException, AuthorizeException {
+    public void runHarvest(int recentDays) throws SQLException, IOException, AuthorizeException {
         Context.Mode originalMode = ourContext.getCurrentMode();
         ourContext.setMode(Context.Mode.BATCH_EDIT);
 
@@ -334,6 +336,9 @@ public class OAIHarvester {
         }
 
         String fromDate = harvestRow.getHarvestDate() == null ? null : processDate(harvestRow.getHarvestDate());
+        if (recentDays > 0) {
+            fromDate = processDate(new Date(System.currentTimeMillis() - ((long) recentDays * 24 * 60 * 60 * 1000)));
+        }
 
         long totalListSize = 0;
         long currentRecord = 0;


### PR DESCRIPTION
1. set the last harvested time to retrieve only updates from the OAI provider
2. optional `-recent` to specify the number of days to look back for updates